### PR TITLE
Issue #54: Download button and link fixes

### DIFF
--- a/data-preparation.html
+++ b/data-preparation.html
@@ -70,7 +70,7 @@
                 <div>
                   <b>Note:</b> The CIB Mango Tree does not scrape your social media activity directly. Instead, it is used in the post-analysis 
                   phase to help you recognize patterns of CIB activity. If you need assistance with scraping data, you can find various tools online, such as 
-                  <a href="https://quickscraper.co/">Quick Scraper</a>.<br><br>  
+                  <a href="https://quickscraper.co/" target="_blank" rel="noopener noreferrer">Quick Scraper</a>.<br><br>  
 
                   When you scrape your social media activity, the resulting dataset will be likely in a .csv, .json, or .xlsx format. 
                   The specific attributes of these columns are called parameters. The CIB Mango Tree's command line interface provides a set of tests 

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -26,10 +26,6 @@
     }
   }
 
-.header-link {
-    color: inherit;
-}
-
 .nav .dropdown-menu {
     position: static;
     display: block;

--- a/download-and-install.html
+++ b/download-and-install.html
@@ -111,9 +111,9 @@
               <h1>Python Module Version</h1>
               <div class="mb-2">
                 <p>For the convenience of our users, an open source version of the program is available for  
-                  <a href="https://github.com/CIB-Mango-Tree/mango-tango-cli">download here</a>. This version can 
-                  be run through a Python language interpreter and allow users more control and customization 
-                  to their tests.
+                  <a href="https://github.com/CIB-Mango-Tree/mango-tango-cli" target="_blank" rel="noopener noreferrer">
+                  download here</a>. This version can be run through a Python language interpreter and allow 
+                  users more control and customization to their tests.
                 </p>
               </div>
 
@@ -126,7 +126,7 @@
               <!-- Python Download Instructions with Image -->
               <ol>
                 <li class="mb-2">
-                  Navigate to <a href="https://www.python.org/downloads/">the download tab of the Python.org website</a>.
+                  Navigate to <a href="https://www.python.org/downloads/" target="_blank" rel="noopener noreferrer">the download tab of the Python.org website</a>.
                 </li>
                 <li class="mb-2">
                   Click to download the relevant Python language interpreter for your operating system.

--- a/download-and-install.html
+++ b/download-and-install.html
@@ -72,30 +72,19 @@
                   Download the CIB Mango Tree program here:
                 </div>
                 <div class="col-12 col-xl-8 row">
-                  <button class="col-6 download-button">
-                    <div>
-                      Download For PC
+                  <a class="col-auto" href="https://github.com/CIB-Mango-Tree/mango-tango-cli/releases" target="_blank" rel="noopener noreferrer">
+                    <button class="col-6 download-button">
                       <div>
-                        <img class="download-small-icon" src="docs/images/windows.png" alt="Windows icon">
-                        <img class="download-small-icon" src="docs/images/download.png" alt="Download icon">
+                        Download
+                        <div>
+                          <img class="download-small-icon" src="docs/images/download.png" alt="Download icon">
+                        </div>
                       </div>
-                    </div>
-                    <div>
-                      <img class="download-mango-icon" src="docs/images/mango-icon.PNG" alt="Mango icon">
-                    </div>
-                  </button>
-                  <button class="col-6 download-button">
-                    <div>
-                      Download For Mac
                       <div>
-                        <img class="download-small-icon" src="docs/images/apple.png" alt="Apple logo">
-                        <img class="download-small-icon" src="docs/images/download.png" alt="Download icon">
+                        <img class="download-mango-icon" src="docs/images/mango-icon.PNG" alt="Mango icon">
                       </div>
-                    </div>
-                    <div>
-                      <img class="download-mango-icon" src="docs/images/mango-icon.PNG" alt="Mango icon">
-                    </div>
-                  </button>
+                    </button>
+                  </a>
                 </div>
               </div>
 

--- a/index.html
+++ b/index.html
@@ -166,16 +166,17 @@
                       <div class="accordion-body">
                         <ul>
                           <li class="list-item"><strong>Meta: </strong>
-                            <a href="https://about.fb.com/news/2018/12/inside-feed-coordinated-inauthentic-behavior/">
+                            <a href="https://about.fb.com/news/2018/12/inside-feed-coordinated-inauthentic-behavior/" target="_blank" rel="noopener noreferrer">
                               Coordinated Inauthentic Behavior Explained</a></li>
                           <li class="list-item"><strong>Stanford University:</strong>
-                            <a href="https://cyber.fsi.stanford.edu/content/how-coordinated-inauthentic-behavior-continues-social-platforms">
+                            <a href="https://cyber.fsi.stanford.edu/news/how-coordinated-inauthentic-behavior-continues-social-platforms" target="_blank" rel="noopener noreferrer">
                               How Coordinated Inauthentic Behavior continues on Social Platforms</a></li>
                           <li class="list-item"><strong>Atlantic Council:</strong>
-                            <a href="https://www.atlanticcouncil.org/programs/digital-forensic-research-lab/">
+                            <a href="https://www.atlanticcouncil.org/programs/digital-forensic-research-lab/" target="_blank" rel="noopener noreferrer">
                               The Digital Forensic Research Lab</a></li>
                           <li class="list-item"><strong>The Global Disinformation Index:</strong>
-                            <a href="https://www.disinformationindex.org/" target="_blank" rel="noopener noreferrer">Research and Reports</a></li>
+                            <a href="https://www.disinformationindex.org/" target="_blank" rel="noopener noreferrer">
+                              Research and Reports</a></li>
                         </ul>
                       </div>
                     </div>


### PR DESCRIPTION
- Restored single download button that links to GitHub
- Re-fixed Stanford article link on About page
- Reinstated external links opening in new tab