### PR TITLE
Fix:  Logo click now navigates to About page from news Page (Fixes #78)

### DIFF
--- a/news.html
+++ b/news.html
@@ -99,7 +99,7 @@
       <!-- Navbar -->
       <nav class="navbar sticky-top navbar-expand-md navbar-light bg-light pb-4">
         <!-- Navbar Logo -->
-        <a class="navbar-brand d-flex flex-row align-items-center ps-md-4 ps-4" href="news.html">
+        <a class="navbar-brand d-flex flex-row align-items-center ps-md-4 ps-4" href="index.html">
           <img class="header-logo" src="docs/images/mango-text.PNG">
           <div class="d-flex flex-column ps-3 ps-md-2">
             <p class="header-text mb-0">CIB Mango Tree</p>


### PR DESCRIPTION
This PR fixes an issue where clicking the logo on the News page did not initiate navigation back to the About screen. The issue was caused by an incorrect value being assigned to the href attribute.

Changes:
Updated the logo’s href to correctly point to the home page.

Issue Reference
Fixes #78 